### PR TITLE
hotfix: improve orphaned images cleanup in game update form

### DIFF
--- a/src/components/publisher/gameDetails/UpdateGameDetailsForm.vue
+++ b/src/components/publisher/gameDetails/UpdateGameDetailsForm.vue
@@ -459,7 +459,12 @@ const thumbnailUrlData = ref<string>(
     ? gameToMutate.value.thumbnail
     : 'https://ccdn.steak.io.vn/assets-desert.png',
 )
-
+const data_to_assigned = ref<
+  {
+    url: string
+    type: 'video' | 'image'
+  }[]
+>([])
 const completedApis = ref(0)
 const totalApis = 5
 const progressValue = computed(() => Math.floor((completedApis.value / totalApis) * 100))
@@ -526,7 +531,7 @@ const handleSaveAsDraft = async () => {
     )
     await mutatePostIntoPresignedUrls(dataPostIntoPresignedUrls)
     if (response) {
-      const data_to_assigned = response.map((file: PresignedUrlResponse, index: number) => {
+      data_to_assigned.value = response.map((file: PresignedUrlResponse, index: number) => {
         const { cdnFileName } = file
         return {
           url: `https://ccdn.steak.io.vn/${cdnFileName}`,
@@ -535,7 +540,7 @@ const handleSaveAsDraft = async () => {
       })
       await new Promise((resolve) => {
         setTimeout(() => {
-          data_to_assigned.forEach((media) => {
+          data_to_assigned.value.forEach((media) => {
             if (!gameToMutate.value.media) {
               gameToMutate.value.media = []
             }
@@ -573,9 +578,9 @@ const handleSaveAsDraft = async () => {
         toastErrorNotificationPopup('Failed to save as draft', 'Please try again later.')
       }
     } catch (error: any) {
-      if (gameToMutate.value?.media) {
+      if (data_to_assigned.value) {
         await mutateDeleteImages(
-          gameToMutate.value.media?.map((media) => media.url).filter((url) => url !== undefined),
+          data_to_assigned.value?.map((media) => media.url).filter((url) => url !== undefined),
         )
       }
       toastErrorNotificationPopup(


### PR DESCRIPTION
This pull request introduces changes to improve the handling of media data (`video` or `image`) during the "Save as Draft" process in the `UpdateGameDetailsForm.vue` file. The key updates include the introduction of a new reactive reference for managing media data and ensuring consistent access to this data throughout the workflow.

### Media data handling improvements:

* Introduced a new reactive reference `data_to_assigned` to manage media data, which includes `url` and `type` properties for each media item. (`[src/components/publisher/gameDetails/UpdateGameDetailsForm.vueL462-R467](diffhunk://#diff-e2593b37aa2f49e451ecdf37ad1f080383c9949d43fa6f8df69b1b28471ec962L462-R467)`)
* Updated the `handleSaveAsDraft` method to assign the mapped response directly to `data_to_assigned.value` instead of creating a new constant. (`[src/components/publisher/gameDetails/UpdateGameDetailsForm.vueL529-R534](diffhunk://#diff-e2593b37aa2f49e451ecdf37ad1f080383c9949d43fa6f8df69b1b28471ec962L529-R534)`)
* Replaced direct access to `data_to_assigned` with `data_to_assigned.value` when iterating over media items, ensuring proper reactivity. (`[src/components/publisher/gameDetails/UpdateGameDetailsForm.vueL538-R543](diffhunk://#diff-e2593b37aa2f49e451ecdf37ad1f080383c9949d43fa6f8df69b1b28471ec962L538-R543)`)
* Modified error handling to use `data_to_assigned.value` for deleting media URLs when an error occurs, improving consistency and avoiding reliance on `gameToMutate.value.media`. (`[src/components/publisher/gameDetails/UpdateGameDetailsForm.vueL576-R583](diffhunk://#diff-e2593b37aa2f49e451ecdf37ad1f080383c9949d43fa6f8df69b1b28471ec962L576-R583)`)- Fix data_to_assigned variable scope to properly track uploaded media files
- Ensure uploaded images are properly cleaned up on error during draft save
- Change from local variable to ref for better reactivity and error handling
- Fix reference issues in media cleanup logic to prevent orphaned CDN files

This prevents CDN storage bloat when game update operations fail partway through.