### PR TITLE
fix-refresh-error

### DIFF
--- a/src/apis/publisher/auth/authPublisher.ts
+++ b/src/apis/publisher/auth/authPublisher.ts
@@ -1,5 +1,6 @@
 import SteakApi from '@/apis/index'
 import { PublisherLoginRequest, type PublisherRegisterRequest } from '@/types/publisher/AuthType'
+import { generateDeviceId, generateDeviceInfo } from '@/utils/fingerprint'
 
 export const register = (data: PublisherRegisterRequest) => {
   return SteakApi.post('/dev/auth/register', data)
@@ -18,5 +19,8 @@ export const logout = () => {
 }
 
 export const renewPublisherRefreshToken = async () => {
-  return await SteakApi.post('/dev/auth/refresh')
+  return await SteakApi.post('/dev/auth/refresh',{
+    deviceId: await generateDeviceId(),
+    deviceInfo: await generateDeviceInfo(),
+  })
 }


### PR DESCRIPTION
This pull request updates the `authPublisher` API to enhance security by including device-specific information in the refresh token request. The changes primarily involve integrating utility functions for generating device identifiers and information.

### Security Enhancements:

* [`src/apis/publisher/auth/authPublisher.ts`](diffhunk://#diff-292f0a8c8a351fdf537245290d5ce952daa9887cc3263e2e83839e68c2272ca5L21-R25): Updated the `renewPublisherRefreshToken` function to include `deviceId` and `deviceInfo` in the payload for the refresh token API request.