### PR TITLE
add-privacy-policy-and-terms-of-service

### DIFF
--- a/public/privacy-policy.html
+++ b/public/privacy-policy.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chính sách bảo mật – Steak</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-gray-100 p-6">
+<div class="max-w-4xl mx-auto bg-gray-800 shadow-lg rounded-2xl p-8">
+  <h1 class="text-3xl font-bold mb-6 text-center">Chính sách bảo mật – Steak Game Marketplace</h1>
+  <p class="mb-4 text-gray-400"><strong>Cập nhật lần cuối:</strong> 14/08/2025</p>
+
+  <p class="mb-4">
+    Steak cam kết bảo vệ quyền riêng tư của người dùng. Ứng dụng hiện đang trong <strong>giai đoạn thử nghiệm (beta)</strong>.
+  </p>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">1. Thông tin chúng tôi thu thập</h2>
+  <ul class="list-disc pl-6 space-y-2">
+    <li>Thông tin đăng ký: tên, email, mật khẩu.</li>
+    <li>Lịch sử mua/tải game (miễn phí nhưng lưu để hiển thị thư viện).</li>
+    <li>Dữ liệu kỹ thuật: IP, trình duyệt, thiết bị.</li>
+  </ul>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">2. Cách chúng tôi sử dụng thông tin</h2>
+  <ul class="list-disc pl-6 space-y-2">
+    <li>Cải thiện trải nghiệm người dùng và nền tảng.</li>
+    <li>Hiển thị thư viện, gợi ý và thông báo.</li>
+    <li>Liên lạc với bạn về cập nhật hoặc bảo trì.</li>
+  </ul>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">3. Bảo mật thông tin</h2>
+  <p>Chúng tôi áp dụng biện pháp bảo mật để bảo vệ thông tin. Không chia sẻ với bên thứ ba nếu không có sự đồng ý hoặc yêu cầu pháp luật.</p>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">4. Cookies và công nghệ tương tự</h2>
+  <p>Steak dùng cookie để cải thiện trải nghiệm, phân tích lưu lượng, hiển thị thông tin phù hợp.</p>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">5. Quyền của bạn</h2>
+  <ul class="list-disc pl-6 space-y-2">
+    <li>Truy cập, chỉnh sửa hoặc xóa thông tin cá nhân.</li>
+    <li>Rút lại sự đồng ý sử dụng thông tin bất cứ lúc nào.</li>
+  </ul>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">6. Liên hệ</h2>
+  <p>📧 <a href="mailto:baonqps41272@gmail.com" class="text-blue-400 underline">baonqps41272@gmail.com</a><br>
+    📍 Bravos Team – Somewhere on Earth</p>
+</div>
+</body>
+</html>

--- a/public/terms-of-service.html
+++ b/public/terms-of-service.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Điều khoản dịch vụ – Steak</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-900 text-gray-100 p-6">
+<div class="max-w-4xl mx-auto bg-gray-800 shadow-lg rounded-2xl p-8">
+  <h1 class="text-3xl font-bold mb-6 text-center">Điều khoản dịch vụ – Steak Game Marketplace</h1>
+  <p class="mb-4 text-gray-400"><strong>Cập nhật lần cuối:</strong> 14/08/2025</p>
+
+  <p class="mb-4">
+    Chào mừng bạn đến với <strong>Steak</strong> – sàn giao dịch game bản quyền của <strong>Bravos Team</strong>.
+    Ứng dụng hiện đang trong giai đoạn <strong>thử nghiệm (beta)</strong>. Bằng việc sử dụng, bạn đồng ý tuân theo các điều khoản dưới đây.
+  </p>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">1. Giới thiệu</h2>
+  <p>Steak là nền tảng cho phép người dùng mua, bán, tải game, đồng thời cung cấp mạng xã hội mini cho nhà phát hành. Mọi hoạt động phải tuân theo pháp luật và điều khoản này.</p>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">2. Tài khoản người dùng</h2>
+  <ul class="list-disc pl-6 space-y-2">
+    <li>Bạn phải từ 13 tuổi trở lên để sử dụng Steak.</li>
+    <li>Thông tin đăng ký phải chính xác. Bạn chịu trách nhiệm bảo mật tài khoản.</li>
+  </ul>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">3. Nội dung và quyền sở hữu</h2>
+  <ul class="list-disc pl-6 space-y-2">
+    <li>Tất cả game và tài nguyên trên Steak thuộc quyền sở hữu của nhà phát hành.</li>
+    <li>Bạn không được sao chép hoặc bán lại nội dung mà không có phép.</li>
+  </ul>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">4. Giao dịch và thanh toán</h2>
+  <ul class="list-disc pl-6 space-y-2">
+    <li>Tất cả giao dịch trên Steak đều <strong>miễn phí</strong>.</li>
+    <li>Thông tin cá nhân được <strong>bảo mật tuyệt đối</strong>.</li>
+  </ul>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">5. Hành vi bị cấm</h2>
+  <ul class="list-disc pl-6 space-y-2">
+    <li>Bán hàng giả hoặc key lậu.</li>
+    <li>Spam, quấy rối hoặc gửi tin nhắn rác.</li>
+    <li>Tấn công hệ thống hoặc cheat.</li>
+  </ul>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">6. Bảo hành và giới hạn trách nhiệm</h2>
+  <p>Dịch vụ cung cấp "nguyên trạng", không đảm bảo game chạy mượt. Không chịu trách nhiệm nếu game không hợp gu hoặc máy bạn yếu.</p>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">7. Chấm dứt dịch vụ</h2>
+  <p>Chúng tôi có quyền tạm ngừng hoặc chấm dứt tài khoản nếu bạn vi phạm điều khoản. Bạn có thể xóa tài khoản bất cứ lúc nào.</p>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">8. Sửa đổi điều khoản</h2>
+  <p>Steak có thể cập nhật điều khoản bất kỳ lúc nào, sẽ thông báo qua email hoặc trong ứng dụng.</p>
+
+  <h2 class="text-xl font-semibold mt-6 mb-2">9. Liên hệ</h2>
+  <p>📧 <a href="mailto:baonqps41272@gmail.com" class="text-blue-400 underline">baonqps41272@gmail.com</a><br>
+  📍 Bravos Team – Somewhere on Earth</p>
+</div>
+</body>
+</html>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,12 +12,16 @@ import storeRoutes from '@/router/routes/store/StoreRoutes'
 import testRoute from '@/router/routes/test/TestRoute'
 import { MiddlewareContext } from '@/types/router/middleware'
 import { getCookie } from '@/utils/cookies/cookie-utils'
+import { TermsOfServiceRoute } from '@/router/routes/policy/termsOfService'
+import { PrivacyPolicyRoute } from '@/router/routes/policy/privacyPolicy'
 
 const routes: RouteRecordRaw[] = [
   testRoute,
   homeRoutes,
   authRoutes,
   storeRoutes,
+  TermsOfServiceRoute,
+  PrivacyPolicyRoute,
   // userRoutes,
   ...paymentRoute,
   ...publisherRoutes,

--- a/src/router/routes/policy/privacyPolicy.ts
+++ b/src/router/routes/policy/privacyPolicy.ts
@@ -1,0 +1,15 @@
+// router/routes.ts
+import type { RouteRecordRaw } from 'vue-router'
+
+export const PrivacyPolicyRoute: RouteRecordRaw = {
+  path: '/privacy-policy',
+  name: 'PrivacyPolicy',
+  beforeEnter() {
+    window.location.href = '/privacy-policy.html'
+  },
+  meta: {
+    title: 'Privacy Policy',
+    description: 'Privacy Policy for our application',
+    requiresAuth: false
+  },
+}

--- a/src/router/routes/policy/termsOfService.ts
+++ b/src/router/routes/policy/termsOfService.ts
@@ -1,0 +1,15 @@
+// router/routes.ts
+import type { RouteRecordRaw } from 'vue-router'
+
+export const TermsOfServiceRoute: RouteRecordRaw = {
+  path: '/terms-of-service',
+  name: 'TermsOfService',
+  beforeEnter() {
+    window.location.href = '/terms-of-service.html'
+  },
+  meta: {
+    title: 'Terms of Service',
+    description: 'Terms of Service for our application',
+    requiresAuth: false
+  },
+}


### PR DESCRIPTION
This pull request introduces new static pages for the privacy policy and terms of service, and integrates them into the application's routing system. The main goal is to provide users with easy access to these important legal documents via dedicated routes, using client-side redirects to static HTML files.

**New static policy pages:**

* Added `public/privacy-policy.html` containing a styled privacy policy in Vietnamese for the Steak Game Marketplace, outlining data collection, usage, security, cookies, user rights, and contact information.
* Added `public/terms-of-service.html` with a styled terms of service in Vietnamese, covering platform introduction, user accounts, content ownership, transactions, prohibited behaviors, warranty/disclaimer, service termination, modifications, and contact details.

**Routing integration:**

* Created `src/router/routes/policy/privacyPolicy.ts` and `src/router/routes/policy/termsOfService.ts` defining routes `/privacy-policy` and `/terms-of-service` that redirect users to the respective static HTML pages. [[1]](diffhunk://#diff-03f397fcd2a08d3fc29db06ab6a0dd8a8ae64bc0594d86221ffb1fdb5ffddb9eR1-R15) [[2]](diffhunk://#diff-973902b73c3e5d89180a61e8a118931d0aadfb7a67f5909a26d6c9da2f33612bR1-R15)
* Updated `src/router/index.ts` to register the new policy routes, making them accessible within the application's main router configuration.